### PR TITLE
fix: improve accessibility in editor window

### DIFF
--- a/packages/solid-repl/src/components/editor/index.tsx
+++ b/packages/solid-repl/src/components/editor/index.tsx
@@ -91,6 +91,7 @@ const Editor: Component<{
       minimap: {
         enabled: props.withMinimap,
       },
+      editContext: false,
     });
 
     createEffect(() => {


### PR DESCRIPTION
This change will bring back `textarea` instead of an `div` as the editor container.

I have [vimium](https://github.com/philc/vimium) as extension that listen on keyboard inputs, if the active element is not an inputable context it will triggers keyboard shortcut instead of plain text.
Overall speaking, i think textarea will be the best for accessibility than a div.

Some references https://github.com/microsoft/monaco-editor/issues/5059, https://github.com/microsoft/vscode/pull/227608.