### PR TITLE
Fix Solid 2 REPL integration

### DIFF
--- a/packages/playground/src/components/header.tsx
+++ b/packages/playground/src/components/header.tsx
@@ -33,6 +33,7 @@ const titleStyles = css({
   lineHeight: 0,
   letterSpacing: 'widest',
   textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
 });
 
 const menuButtonOnMobile = css({

--- a/packages/playground/src/pages/edit.tsx
+++ b/packages/playground/src/pages/edit.tsx
@@ -187,10 +187,9 @@ export const Edit = () => {
     if (changed) trueSetTabs(current.slice());
   };
 
-  const changeSolidVersion = async (version: string) => {
+  const changeSolidVersion = (version: string) => {
     setSolidVersion(version);
     localStorage.setItem('solidVersion', version);
-    migrateTabs((await resolveSolidVersion(version)) || undefined);
   };
 
   context.setTabs(tabs);
@@ -226,6 +225,11 @@ export const Edit = () => {
       return output;
     },
   );
+
+  createEffect(() => {
+    if (resolvedSolidVersion.loading || !resource()) return;
+    migrateTabs(resolvedSolidVersion() || undefined);
+  });
 
   const reset = () => {
     setTabs(mapTabs(defaultTabs));

--- a/packages/playground/src/pages/edit.tsx
+++ b/packages/playground/src/pages/edit.tsx
@@ -1,7 +1,7 @@
 import CompilerWorker from 'solid-repl/repl/compiler?worker';
 import FormatterWorker from 'solid-repl/repl/formatter?worker';
 import LinterWorker from 'solid-repl/repl/linter?worker';
-import { createEffect, createResource, createSignal, lazy, onCleanup, Show, Suspense } from 'solid-js';
+import { batch, createEffect, createResource, createSignal, lazy, onCleanup, Show, Suspense } from 'solid-js';
 import { useLocation, useMatch, useNavigate, useParams } from '@solidjs/router';
 import { API, useAppContext } from '../context';
 import { debounce } from '@solid-primitives/scheduled';
@@ -158,12 +158,11 @@ export const Edit = () => {
     }
     return localStorage.getItem(cacheKey) ?? '';
   };
-  const [resolvedSolidVersion] = createResource(solidVersion, resolveSolidVersion, {
-    initialValue:
-      storedVersion === 'next' || storedVersion === 'latest'
-        ? (localStorage.getItem(`solidVersion:${storedVersion}`) ?? '')
-        : storedVersion,
-  });
+  const initialResolvedSolidVersion =
+    storedVersion === 'next' || storedVersion === 'latest'
+      ? (localStorage.getItem(`solidVersion:${storedVersion}`) ?? '')
+      : storedVersion;
+  const [resolvedSolidVersion, setResolvedSolidVersion] = createSignal(initialResolvedSolidVersion);
 
   const migrateTabs = (version: string | undefined) => {
     const isV2 = isSolidV2(version);
@@ -187,9 +186,21 @@ export const Edit = () => {
     if (changed) trueSetTabs(current.slice());
   };
 
+  let solidVersionRequest = 0;
+  const applySolidVersion = async (version: string) => {
+    const request = ++solidVersionRequest;
+    const resolved = await resolveSolidVersion(version);
+    if (request !== solidVersionRequest || version !== solidVersion()) return;
+    batch(() => {
+      setResolvedSolidVersion(resolved);
+      migrateTabs(resolved || undefined);
+    });
+  };
+
   const changeSolidVersion = (version: string) => {
     setSolidVersion(version);
     localStorage.setItem('solidVersion', version);
+    void applySolidVersion(version);
   };
 
   context.setTabs(tabs);
@@ -221,15 +232,11 @@ export const Edit = () => {
       }
 
       setTabs(output.files.map((x) => ({ name: x.name, source: x.content })));
+      await applySolidVersion(solidVersion());
 
       return output;
     },
   );
-
-  createEffect(() => {
-    if (resolvedSolidVersion.loading || !resource()) return;
-    migrateTabs(resolvedSolidVersion() || undefined);
-  });
 
   const reset = () => {
     setTabs(mapTabs(defaultTabs));

--- a/packages/solid-repl/src/components/editor/codemirrorTabs.ts
+++ b/packages/solid-repl/src/components/editor/codemirrorTabs.ts
@@ -30,6 +30,7 @@ export interface CodemirrorTabsOptions {
   isDark: () => boolean;
   fontSize: () => number;
   displayErrors: () => boolean;
+  eslintEnabled?: () => boolean;
   formatter?: WorkerClient;
   linter?: WorkerClient;
   keyBindings?: KeyBinding[];
@@ -69,6 +70,7 @@ export interface CodemirrorTabs {
   fix(fileId: string): Promise<void>;
   getView(fileId: string): EditorView | undefined;
   ensureOutputView(): OutputView;
+  refreshDiagnostics(): void;
   syncTypes(importMap: Record<string, string>): void;
   session: TypescriptSession;
 }
@@ -183,7 +185,7 @@ const buildLintExtension = (
         session.client.sync();
         diagnostics.push(...(await session.getDiagnostics(uri, view)));
       }
-      if (isTs) {
+      if (isTs && (opts.eslintEnabled?.() ?? true)) {
         const res = await opts.linter?.tryRequest<LintResponse>('LINT', { code: view.state.doc.toString() });
         diagnostics.push(...markersToDiagnostics(view, res?.markers ?? []));
       }
@@ -214,7 +216,7 @@ export const createCodemirrorTabs = (folder: string, opts: CodemirrorTabsOptions
   };
 
   const fixView = async (view: EditorView) => {
-    if (!opts.displayErrors()) return;
+    if (!opts.displayErrors() || !(opts.eslintEnabled?.() ?? true)) return;
     const res = await opts.linter?.tryRequest<LintResponse>('FIX', { code: view.state.doc.toString() });
     if (res?.fixed && typeof res.output === 'string') replaceDoc(view, res.output);
   };
@@ -464,6 +466,11 @@ export const createCodemirrorTabs = (folder: string, opts: CodemirrorTabsOptions
     ensureOutputView() {
       if (!outputEntry) outputEntry = buildOutput();
       return outputEntry.wrapper;
+    },
+    refreshDiagnostics() {
+      for (const lookup of lookups.values()) {
+        lookup.view.dispatch({ effects: typesRefreshed.of(null) });
+      }
     },
     syncTypes(importMap) {
       session

--- a/packages/solid-repl/src/components/editor/tsWorker.ts
+++ b/packages/solid-repl/src/components/editor/tsWorker.ts
@@ -19,6 +19,11 @@ const compilerOptions: CompilerOptions = {
   allowNonTsExtensions: true,
 };
 
+const completionPreferences = {
+  includeCompletionsForModuleExports: true,
+  includeCompletionsForImportStatements: true,
+} satisfies ts.UserPreferences;
+
 const tsLibs = import.meta.glob<string>(
   [
     '/node_modules/typescript/lib/lib.*.d.ts',
@@ -100,6 +105,35 @@ const positionConverters = (env: VirtualTypeScriptEnvironment, uri: string) => {
   };
 };
 
+const completionDetails = (uri: string, offset: number, entry: ts.CompletionEntry) =>
+  env.languageService.getCompletionEntryDetails(
+    uri,
+    offset,
+    entry.name,
+    {},
+    entry.source,
+    completionPreferences,
+    entry.data,
+  );
+
+const completionActionEdits = (uri: string, details: ts.CompletionEntryDetails | undefined) => {
+  if (!details?.codeActions) return [];
+  const { offsetToPos } = positionConverters(env, uri);
+  return details.codeActions.flatMap((action) =>
+    action.changes.flatMap((change) =>
+      change.fileName === uri
+        ? change.textChanges.map(({ span, newText }) => ({
+            range: {
+              start: offsetToPos(span.start),
+              end: offsetToPos(span.start + span.length),
+            },
+            newText,
+          }))
+        : [],
+    ),
+  );
+};
+
 const ensureFile = (uri: string, text: string) => {
   openDocs.set(uri, text);
   const existing = env.getSourceFile(uri);
@@ -141,16 +175,26 @@ const handleRequest = (method: string, params: any) => {
       const uri = params.textDocument.uri;
       const { posToOffset } = positionConverters(env, uri);
       const offset = posToOffset(params.position);
-      const completions = env.languageService.getCompletionsAtPosition(uri, offset, {});
+      const completions = env.languageService.getCompletionsAtPosition(uri, offset, completionPreferences);
       if (!completions) return null;
+      const prefix = openDocs.get(uri)?.slice(0, offset).match(/[\w$]+$/)?.[0].toLowerCase();
       return {
         isIncomplete: !!completions.isIncomplete,
-        items: completions.entries.map((c) => ({
-          label: c.name,
-          kind: completionItemKind[c.kind] ?? 1,
-          sortText: c.sortText,
-          data: { uri, offset, name: c.name, source: c.source },
-        })),
+        items: completions.entries.map((c) => {
+          const details =
+            c.hasAction && prefix && c.name.toLowerCase().startsWith(prefix)
+              ? completionDetails(uri, offset, c)
+              : undefined;
+          const additionalTextEdits = completionActionEdits(uri, details);
+          return {
+            label: c.name,
+            kind: completionItemKind[c.kind] ?? 1,
+            sortText: c.sortText,
+            insertText: c.insertText,
+            additionalTextEdits: additionalTextEdits.length ? additionalTextEdits : undefined,
+            data: { uri, offset, name: c.name, source: c.source, entryData: c.data },
+          };
+        }),
       };
     }
 
@@ -163,8 +207,8 @@ const handleRequest = (method: string, params: any) => {
         data.name,
         {},
         data.source,
-        undefined,
-        undefined,
+        completionPreferences,
+        data.entryData,
       );
       if (!details) return params;
       const detail = displayPartsToString(details.displayParts);

--- a/packages/solid-repl/src/components/mobile.tsx
+++ b/packages/solid-repl/src/components/mobile.tsx
@@ -1,6 +1,6 @@
 import { Component, For, JSX, Show, createEffect, createSignal, onCleanup, onMount } from 'solid-js';
 import { Icon } from 'solid-heroicons';
-import { plus, xMark } from 'solid-heroicons/outline';
+import { arrowPath, plus, xMark } from 'solid-heroicons/outline';
 import { NewTab } from './newTab';
 import { ImportMapPanel } from './importMapPanel';
 import Editor from './editor';
@@ -15,6 +15,7 @@ interface MobileReplProps {
   onPreviewOpen: (open: boolean) => void;
   onOutputOpen: (open: boolean) => void;
   onActiveFile: (id: string) => void;
+  onRefreshPreview: () => void;
 }
 
 const CARD_SCALE = 0.7;
@@ -367,6 +368,12 @@ export const MobileRepl: Component<MobileReplProps> = (props) => {
             {activeId() ? labelOf(activeId()!) : ''}
           </Show>
         </div>
+        <Show when={!switcher() && activeId() === 'Preview'}>
+          <button class={barButton} onClick={props.onRefreshPreview} title="Refresh preview">
+            <Icon path={arrowPath} class={css({ h: 5, w: 5 })} />
+            <span class={css({ srOnly: true })}>Refresh preview</span>
+          </button>
+        </Show>
         <button
           class={tabCount}
           classList={{ [tabCountActive]: switcher() }}

--- a/packages/solid-repl/src/components/preview.tsx
+++ b/packages/solid-repl/src/components/preview.tsx
@@ -269,6 +269,12 @@ export const Preview: Component<Props> = (props) => {
     iframe.contentWindow?.postMessage(msg, '*');
   };
 
+  const refreshPreview = () => {
+    if (!iframe) return;
+    isIframeReady = false;
+    iframe.srcdoc = iframeHtml;
+  };
+
   const devtoolsSrc = useDevtoolsSrc();
 
   const styleScale = () => {
@@ -343,8 +349,12 @@ export const Preview: Component<Props> = (props) => {
       void props.importMap;
       if (!isIframeReady) return;
       // A changed import map only takes effect in a fresh document.
-      isIframeReady = false;
-      iframe.srcdoc = iframeHtml;
+      refreshPreview();
+    });
+
+    createEffect(() => {
+      void props.refreshKey;
+      if (props.code['./main']) sendToIframe({ event: 'CODE_UPDATE', value: props.code });
     });
 
     createEffect(() => {
@@ -389,4 +399,5 @@ type Props = {
   devtools: boolean;
   isDark: boolean;
   pointerEvents: boolean;
+  refreshKey: number;
 };

--- a/packages/solid-repl/src/components/repl.tsx
+++ b/packages/solid-repl/src/components/repl.tsx
@@ -38,7 +38,7 @@ import {
   themeAbyssSpaced,
 } from 'dockview-core';
 import { Icon } from 'solid-heroicons';
-import { plus, trash, xMark } from 'solid-heroicons/outline';
+import { arrowPath, plus, trash, xMark } from 'solid-heroicons/outline';
 import { css } from 'styled-system/css';
 import '../../node_modules/dockview-core/dist/styles/dockview.css';
 
@@ -128,6 +128,8 @@ export const Repl: ReplProps = (props) => {
 
   const [outputVisible, setOutputVisible] = createSignal(false);
   const [previewVisible, setPreviewVisible] = createSignal(false);
+  const [previewRefreshKey, setPreviewRefreshKey] = createSignal(0);
+  const refreshPreview = () => setPreviewRefreshKey((key) => key + 1);
   const importMap = createMemo(
     () => parseImportMap(props.tabs.find((tab) => tab.name === 'import_map.json')?.source),
     undefined,
@@ -176,6 +178,7 @@ export const Repl: ReplProps = (props) => {
     isDark: () => !!props.dark,
     fontSize: () => zoomState.fontSize,
     displayErrors,
+    eslintEnabled: () => !props.version || parseInt(props.version, 10) < 2,
     formatter,
     linter,
     keyBindings: keyBindingsOf(commands),
@@ -189,6 +192,11 @@ export const Repl: ReplProps = (props) => {
     },
     loadEditorState: (fileId) => props.storage?.getEditorState?.(fileId),
     saveEditorState: (fileId, state) => props.storage?.setEditorState?.(fileId, state),
+  });
+
+  createEffect(() => {
+    void props.version;
+    cmTabs.refreshDiagnostics();
   });
 
   const activeName = () => {
@@ -327,6 +335,7 @@ export const Repl: ReplProps = (props) => {
       devtools={!props.hideDevtools}
       isDark={props.dark}
       pointerEvents={interactive()}
+      refreshKey={previewRefreshKey()}
     />
   );
 
@@ -458,29 +467,45 @@ export const Repl: ReplProps = (props) => {
             );
           }),
         createRightHeaderActionComponent: () => {
-          const [isTSX, setIsTSX] = createSignal(false);
+          const [activePanel, setActivePanel] = createSignal<string>();
+          const isTSX = () => {
+            const id = activePanel();
+            return !!id && !!workspace.nameOf(id)?.endsWith('.tsx');
+          };
 
           return solidPart<IGroupHeaderProps>(
             `${headerActions} ${css({ justifyContent: 'flex-end' })}`,
             () => (
-              <Show when={isTSX()}>
-                <IconButton
-                  icon={trash}
-                  class={css({ h: '28px' })}
-                  onClick={() => {
-                    if (!confirm('Are you sure you want to reset the editor?')) return;
-                    props.reset();
-                  }}
-                  title="Reset Editor"
-                >
-                  <span class={css({ srOnly: true })}>Reset Editor</span>
-                </IconButton>
-              </Show>
+              <>
+                <Show when={activePanel() === 'Preview'}>
+                  <IconButton
+                    icon={arrowPath}
+                    class={css({ h: '28px' })}
+                    onClick={refreshPreview}
+                    title="Refresh preview"
+                  >
+                    <span class={css({ srOnly: true })}>Refresh preview</span>
+                  </IconButton>
+                </Show>
+                <Show when={isTSX()}>
+                  <IconButton
+                    icon={trash}
+                    class={css({ h: '28px' })}
+                    onClick={() => {
+                      if (!confirm('Are you sure you want to reset the editor?')) return;
+                      props.reset();
+                    }}
+                    title="Reset Editor"
+                  >
+                    <span class={css({ srOnly: true })}>Reset Editor</span>
+                  </IconButton>
+                </Show>
+              </>
             ),
             (params) => {
+              setActivePanel(params.group.activePanel?.id);
               const disposable = params.group.api.onDidActivePanelChange((e) => {
-                if (!e) return;
-                setIsTSX(e.panel.id.endsWith('.tsx'));
+                setActivePanel(e?.panel.id);
               });
               return () => disposable.dispose();
             },
@@ -662,6 +687,7 @@ export const Repl: ReplProps = (props) => {
             onPreviewOpen={setPreviewVisible}
             onOutputOpen={setOutputVisible}
             onActiveFile={setActiveFileId}
+            onRefreshPreview={refreshPreview}
           />
         </Show>
         <Show when={error()}>


### PR DESCRIPTION
## Summary
- migrate generated import maps after loading and resolving the selected Solid version
- enable module-export completions and auto-import edits for Solid APIs such as `Loading`
- disable the legacy Solid ESLint integration for Solid 2 while preserving TypeScript diagnostics
- add desktop and mobile preview controls that rerun the latest compiled code without reloading the iframe

## Verification
- `pnpm --filter solid-repl tsc`
- `pnpm --filter solid-playground build`
- `pnpm lint` (passes with existing warnings)