### PR TITLE
Fix @solidjs/signals resolution and add auto-import completions for Solid 2

### DIFF
--- a/packages/playground/src/components/header.tsx
+++ b/packages/playground/src/components/header.tsx
@@ -33,6 +33,7 @@ const titleStyles = css({
   lineHeight: 0,
   letterSpacing: 'widest',
   textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
 });
 
 const menuButtonOnMobile = css({

--- a/packages/solid-repl/src/components/editor/tsWorker.ts
+++ b/packages/solid-repl/src/components/editor/tsWorker.ts
@@ -139,19 +139,47 @@ const handleRequest = (method: string, params: any) => {
 
     case 'textDocument/completion': {
       const uri = params.textDocument.uri;
-      const { posToOffset } = positionConverters(env, uri);
+      const { posToOffset, offsetToPos } = positionConverters(env, uri);
       const offset = posToOffset(params.position);
-      const completions = env.languageService.getCompletionsAtPosition(uri, offset, {});
+      const ls = env.languageService;
+      const completions = ls.getCompletionsAtPosition(uri, offset, { includeCompletionsForModuleExports: true });
       if (!completions) return null;
-      return {
-        isIncomplete: !!completions.isIncomplete,
-        items: completions.entries.map((c) => ({
-          label: c.name,
-          kind: completionItemKind[c.kind] ?? 1,
-          sortText: c.sortText,
-          data: { uri, offset, name: c.name, source: c.source },
-        })),
-      };
+
+      const toItem = (c: ts.CompletionEntry) => ({
+        label: c.name,
+        kind: completionItemKind[c.kind] ?? 1,
+        sortText: c.sortText,
+        data: { uri, offset, name: c.name, source: c.source },
+      });
+
+      // Auto-import entries must carry their import edit up front (the client never sends
+      // completionItem/resolve), so only a bounded, prefix-matched set of them is resolved.
+      const start = completions.optionalReplacementSpan?.start ?? offset;
+      const prefix = (openDocs.get(uri) ?? '').slice(start, offset).toLowerCase();
+      const autoImports = completions.entries
+        .filter(
+          (c) =>
+            c.source &&
+            c.hasAction &&
+            prefix.length >= 2 &&
+            c.name.toLowerCase().startsWith(prefix) &&
+            // solid-js re-exports the signals APIs; its internal type paths aren't importable
+            !/@solidjs\/signals|solid-js\/types\//.test(c.source),
+        )
+        .slice(0, 20)
+        .flatMap((c) => {
+          const details = ls.getCompletionEntryDetails(uri, offset, c.name, {}, c.source, undefined, c.data);
+          const change = details?.codeActions?.[0]?.changes.find((ch) => ch.fileName === uri);
+          const edits = change?.textChanges.map((tc) => ({
+            range: { start: offsetToPos(tc.span.start), end: offsetToPos(tc.span.start + tc.span.length) },
+            newText: tc.newText,
+          }));
+          return edits ? [{ ...toItem(c), additionalTextEdits: edits }] : [];
+        });
+
+      const plain = completions.entries.filter((c) => !c.source || !c.hasAction).map(toItem);
+      // Incomplete so the client re-queries as the word grows instead of filtering its first response.
+      return { isIncomplete: true, items: [...plain, ...autoImports] };
     }
 
     case 'completionItem/resolve': {

--- a/packages/solid-repl/src/kernel/importMap.ts
+++ b/packages/solid-repl/src/kernel/importMap.ts
@@ -6,8 +6,9 @@ export interface ImportMapState {
   pinned: string[];
 }
 
-const EXTERNALIZED = ['solid-js', '@solidjs/web'];
-const SOLID_FAMILY = [...EXTERNALIZED, '@solidjs/signals'];
+// `@solidjs/signals` is externalized too: the v2 preset injects imports of it into
+// compiled output after externals are collected, so it must always be in the map.
+const EXTERNALIZED = ['solid-js', '@solidjs/web', '@solidjs/signals'];
 
 const isSolidV2 = (solidVersion: string | undefined) => !!solidVersion && parseInt(solidVersion, 10) >= 2;
 
@@ -23,7 +24,7 @@ function moduleUrl(importee: string, solidVersion?: string) {
   const isV2 = isSolidV2(solidVersion);
   const target = solidWebAlias(importee, solidVersion) ?? importee;
 
-  const family = isV2 ? SOLID_FAMILY : ['solid-js'];
+  const family = isV2 ? EXTERNALIZED : ['solid-js'];
   const match = family.find((pkg) => target === pkg || target.startsWith(`${pkg}/`));
 
   let url = 'https://esm.sh/';


### PR DESCRIPTION
## Summary

- **Externalize `@solidjs/signals` in the import map (fixes a runtime crash).** The Solid 2 babel preset injects `import ... from '@solidjs/signals'` into compiled output *after* the compiler worker has collected externals, so the preview import map never gained an entry for it and the iframe failed with `Failed to resolve module specifier "@solidjs/signals"`. Adding it to `EXTERNALIZED` gives it a pinned import-map entry, marks it external in the solid-js/@solidjs/web esm.sh URLs (one shared signals runtime instance), and pins its types to the solid-js version so type acquisition no longer relies on jsdelivr's flaky prerelease range resolution.
- **Auto-import completions in the TypeScript worker.** Typing an unimported symbol (e.g. `createProjection`) now suggests it and inserts the `import` statement on accept. Since `@codemirror/lsp-client` never sends `completionItem/resolve` and only applies `additionalTextEdits` present in the initial list, import edits are computed inline for a bounded, prefix-matched set of module-export entries (2+ chars typed, capped at 20), with `isIncomplete: true` so the client re-queries as the word grows. Entries sourced from `@solidjs/signals` re-exports and `solid-js/types/` internals are skipped to avoid duplicates.
- Prevent the mobile header title from wrapping.

## Test plan

- Load a Solid 2 playground, confirm the preview renders without the module-specifier error and that `import_map.json` gains a pinned `@solidjs/signals` entry after the first compile.
- Type `createProj` in an editor tab: `createProjection` should be suggested and accepting it should add `import { createProjection } from "solid-js"` (merged into an existing solid-js import when present).
- Confirm Solid 1 playgrounds are unaffected (v1 paths are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)